### PR TITLE
restrict link specs to the really necessary

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,12 +27,10 @@ list(APPEND gsoap_GEN
 rock_library(camera_onvif
     SOURCES CameraOnvif.cpp ${gsoap_GEN} ${gsoap_PLUGINS_SOURCES}
     HEADERS CameraOnvif.hpp
-    DEPS_PKGCONFIG gsoap gsoap++ gsoapssl libssl libcrypto base-types)
+    DEPS_PKGCONFIG gsoap++ gsoapssl++ libssl libcrypto base-types)
 
 rock_executable(camera_onvif_bin Main.cpp CameraOnvif.cpp
-    ${gsoap_GEN}
-    ${gsoap_PLUGINS_SOURCES}
-    DEPS_PKGCONFIG gsoap gsoap++ gsoapssl libssl libcrypto base-types)
+    DEPS camera_onvif)
 
 set_source_files_properties(${gsoap_PLUGINS_SOURCES} PROPERTIES LANGUAGE CXX)
 


### PR DESCRIPTION
The gsoap (not ++) does not seem to be necessary to build and link,
and it fails with it on 20.04